### PR TITLE
Update app.html

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -6,7 +6,7 @@
     <meta property="og:type" content="website" />
     <meta
       property="og:image"
-      content="https://jill64.github.io/parallel-stopwatch/og-image.png"
+      content="https://parallel-stopwatch.com/og-image.png"
     />
     %sveltekit.head%
   </head>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->


### Summary by CodeRabbit

- Chore: Updated the Open Graph sharing image URL. The image used when sharing the Parallel Stopwatch app on social media platforms has been moved to our official domain. This change ensures consistency in our branding and enhances the reliability of image loading during sharing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->