### PR TITLE
Add @jill64/svelte-ogp package and implement Open Graph Protocol metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@jill64/sentry-sveltekit-cloudflare": "1.0.0",
     "@jill64/svelte-device-theme": "1.1.1",
     "@jill64/svelte-i18n": "0.2.3",
+    "@jill64/svelte-ogp": "^0.0.2",
     "@jill64/svelte-toast": "1.0.0",
     "@jill64/tailwind-grid-auto": "1.1.1",
     "@jill64/tailwind-reactions": "1.0.1",

--- a/src/app.html
+++ b/src/app.html
@@ -1,13 +1,8 @@
 <!doctype html>
-<html prefix="og: http://ogp.me/ns#">
+<html>
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width" />
-    <meta property="og:type" content="website" />
-    <meta
-      property="og:image"
-      content="https://parallel-stopwatch.com/og-image.png"
-    />
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover" data-sveltekit-preload-code="eager">

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,8 +1,10 @@
 import { PUBLIC_SENTRY_DSN } from '$env/static/public'
-import { attach } from '$lib/i18n'
+import { attach as lang_attach } from '$lib/i18n'
 import { serverInit } from '@jill64/sentry-sveltekit-cloudflare'
+import { attach as ogp_attach } from '@jill64/svelte-ogp'
+import { sequence } from '@sveltejs/kit/hooks'
 
 const { onHandle, onError } = serverInit(PUBLIC_SENTRY_DSN)
 
-export const handle = onHandle(attach)
+export const handle = onHandle(sequence(lang_attach, ogp_attach))
 export const handleError = onError()

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -19,15 +19,11 @@
   })
 
   $: suffix = $isDark ? '-dark' : ''
-
-  $: ({
-    url: { href, origin }
-  } = $page)
 </script>
 
 <Toaster position="bottom-right" />
 <LanguageManager />
-<LocaleAlternates xDefaultHref={origin} />
+<LocaleAlternates xDefaultHref={$page.url.origin} />
 <OGP
   {title}
   {description}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,7 +3,8 @@
   import { page } from '$app/stores'
   import { translate } from '$lib/i18n'
   import { isDark } from '@jill64/svelte-device-theme'
-  import { LocaleAlternates, LanguageManager } from '@jill64/svelte-i18n'
+  import { LanguageManager, LocaleAlternates } from '@jill64/svelte-i18n'
+  import { OGP } from '@jill64/svelte-ogp'
   import { Toaster } from '@jill64/svelte-toast'
   import '../app.postcss'
 
@@ -27,14 +28,16 @@
 <Toaster position="bottom-right" />
 <LanguageManager />
 <LocaleAlternates xDefaultHref={origin} />
+<OGP
+  {title}
+  {description}
+  site_name={title}
+  image="https://parallel-stopwatch.com/og-image.png"
+/>
 <svelte:head>
   <link rel="icon" href="{base}/favicon{suffix}.png" />
   <link rel="icon" href="{base}/favicon{suffix}.svg" type="image/svg+xml" />
   <link rel="apple-touch-icon" href="{base}/apple-touch-icon{suffix}.png" />
   <meta name="description" content={description} />
-  <meta property="og:url" content={href} />
-  <meta property="og:title" content={title} />
-  <meta property="og:description" content={description} />
-  <meta property="og:site_name" content={title} />
 </svelte:head>
 <slot />


### PR DESCRIPTION
This PR adds the @jill64/svelte-ogp package to the project and implements Open Graph Protocol metadata. This will allow for better sharing of website content on social media platforms.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Removed Open Graph metadata from HTML file and added SvelteKit-specific code.
- **New Features**
	- Introduced Open Graph Protocol (OGP) support in the app, allowing better integration with social media platforms.
- **Bug Fixes**
	- Fixed import conflicts in the server hooks file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->